### PR TITLE
Add code scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    - cron: '27 2 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      # If you wish to specify custom queries, you can do so here or in a config file.
+      # By default, queries listed here will override any specified in a config file.
+      # Prefix the list here with "+" to use these queries and those in the config file.
+      # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
Hello :wave: from the VA GitHub.com team!

We are requesting via this Pull request that you enable [Advanced Security Code Scanning](https://department-of-veterans-affairs.github.io/github-handbook/guides/security/code-scanning). Advanced Security Code Scanning is a feature on GitHub that the VA is already paying for, and we kindly request that you utilize it to improve your repository's security. This is a compliment to any tools and security procedures your team is already performing rather than a replacement. We are excited to get this enabled as it gets developers information about the security of the code early, before it's even merged in.

This pull request will attempt an **automatic scan for security vulnerabilities in the code of this repository**. If there is a build failure or results that you would like assistance with, we would be happy to work with you. **You can schedule [here](https://calendly.com/security-squad/security-consultation) or reach us at va-delivery@github.com**.

Once merged, this feature will **identify potential security issues on any new pull requests**. These should be reviewed with any security folks on your team. For more information, check out the [GitHub Handbook](https://department-of-veterans-affairs.github.io/github-handbook/guides/security/code-scanning). A great place to start if you have a lot of potential vulnerabilities is to address new vulnerabilities only for a period of time and then scheduling time to regularly reduce the backlog of potential vulnerabilities. This will minimize negative impact to current release schedules and productivity.

With all that being said, please consider merging this once the checks pass. Thank you and happy coding! :octocat: